### PR TITLE
Fix proxy check error by adding protocol to proxy URL

### DIFF
--- a/proxy-gen.py
+++ b/proxy-gen.py
@@ -27,7 +27,8 @@ def proxy_gen() -> str:
 
 
 def check(proxy) -> bool:
-    proxies = {"https": proxy}
+    proxy_url = "http://" + proxy if not proxy.startswith(("http://", "https://")) else proxy
+    proxies = {"https": proxy_url}
     with suppress(Exception):
         response = get(
             "https://api.ipify.org?format=json",


### PR DESCRIPTION
Fix proxy check error by adding protocol to proxy URL
(InvalidURL: Proxy URL had no scheme)